### PR TITLE
Fix Storybook Tailwind

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,4 +1,5 @@
 import type { Preview } from '@storybook/nextjs-vite'
+import '../src/app/globals.css'
 
 const preview: Preview = {
   parameters: {


### PR DESCRIPTION
## Summary
- include globals.css in Storybook preview to enable Tailwind

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Failed to fetch fonts from fonts.googleapis.com)*
- `pnpm build-storybook` *(fails: build errors)*

------
https://chatgpt.com/codex/tasks/task_e_684fa073c1f8832c813d13ecf80eda07